### PR TITLE
fix(ci): pin iOS Release to manual signing, stop minting dev certs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -434,27 +434,31 @@ jobs:
       - name: Archive iOS
         shell: bash
         run: |
+          # Manual signing only — no -allowProvisioningUpdates and no auth key.
+          # The Apple Distribution cert is already imported into the keychain
+          # and the AppStore provisioning profiles are installed under
+          # ~/Library/MobileDevice/Provisioning Profiles. The project's iOS
+          # Release configs pin CODE_SIGN_STYLE=Manual + the profile names,
+          # so xcodebuild resolves everything locally and never calls Apple.
+          # Previously this step ran with -allowProvisioningUpdates, which
+          # caused Xcode to mint a fresh Apple Development cert every CI run
+          # and quickly fill the team's cert quota.
           xcodebuild archive \
             -scheme toss \
             -configuration Release \
             -destination 'generic/platform=iOS' \
-            -archivePath build/Tossinger.xcarchive \
-            -allowProvisioningUpdates \
-            -authenticationKeyPath "${ASC_KEY_PATH}" \
-            -authenticationKeyID "${{ secrets.ASC_KEY_ID }}" \
-            -authenticationKeyIssuerID "${{ secrets.ASC_ISSUER_ID }}"
+            -archivePath build/Tossinger.xcarchive
 
       - name: Export IPA
         shell: bash
         run: |
+          # Same reasoning as the archive step: manual signing, no API calls.
+          # The export options plist already declares signingStyle=manual and
+          # maps each bundle id to its profile.
           xcodebuild -exportArchive \
             -archivePath build/Tossinger.xcarchive \
             -exportOptionsPlist export-options/ios-export-options.plist \
-            -exportPath build/ipa \
-            -allowProvisioningUpdates \
-            -authenticationKeyPath "${ASC_KEY_PATH}" \
-            -authenticationKeyID "${{ secrets.ASC_KEY_ID }}" \
-            -authenticationKeyIssuerID "${{ secrets.ASC_ISSUER_ID }}"
+            -exportPath build/ipa
 
       - name: Upload to TestFlight
         shell: bash

--- a/toss.xcodeproj/project.pbxproj
+++ b/toss.xcodeproj/project.pbxproj
@@ -413,8 +413,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = tossShare/tossShare.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Apple Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 2;
+				DEVELOPMENT_TEAM = RFY9T5P84M;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = tossShare/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = TossingerShare;
@@ -428,6 +430,7 @@
 				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "lutra-labs.toss.tossShare";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "TossShare AppStore";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -577,10 +580,12 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				AUTOMATION_APPLE_EVENTS = YES;
 				CODE_SIGN_ENTITLEMENTS = toss/toss.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 2;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"toss/Preview Content\"";
+				DEVELOPMENT_TEAM = RFY9T5P84M;
 				ENABLE_APP_SANDBOX = YES;
 				"ENABLE_APP_SANDBOX[sdk=macosx*]" = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -621,6 +626,7 @@
 				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "lutra-labs.toss";
 				PRODUCT_NAME = Tossinger;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Tossinger AppStore";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";


### PR DESCRIPTION
## Summary

iOS archive in \`release.yml\` ran with \`-allowProvisioningUpdates\` against an Automatic-signing project. Each CI run minted a fresh Apple Development cert via the ASC API on the ephemeral runner keychain (which only has the imported Apple Distribution cert) and the team's cert quota filled after a handful of runs:

\`\`\`
error: Choose a certificate to revoke. Your account has reached the maximum number of certificates.
error: No profiles for 'lutra-labs.toss' were found: Xcode couldn't find any
       iOS App Development provisioning profiles matching 'lutra-labs.toss'.
\`\`\`

Both errors are downstream of the same loop. Switching iOS Release to manual signing kills it.

## Changes

**\`toss.xcodeproj/project.pbxproj\`** — only the **Release** configurations of \`toss\` and \`tossShare\` are touched. Debug stays Automatic so local development on iOS sim/device is unaffected. Settings are sdk-scoped on the multiplatform \`toss\` target so the macOS build path (which uses \`CODE_SIGNING_ALLOWED=NO\`) is untouched.

- \`tossShare\` Release: \`CODE_SIGN_STYLE = Manual\`, \`CODE_SIGN_IDENTITY = "Apple Distribution"\`, \`PROVISIONING_PROFILE_SPECIFIER = "TossShare AppStore"\`, \`DEVELOPMENT_TEAM = RFY9T5P84M\`.
- \`toss\` Release: same idea but with sdk-scoped variants — \`"CODE_SIGN_IDENTITY[sdk=iphoneos*]"\`, \`"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]"\`. Profile names match what's already in \`export-options/ios-export-options.plist:14-20\`.

**\`.github/workflows/release.yml\`** — drop \`-allowProvisioningUpdates\` and the \`-authenticationKey*\` flags from both \`xcodebuild archive\` and \`xcodebuild -exportArchive\`. With manual signing the cert is in the keychain and the profiles are on disk, so xcodebuild resolves everything locally and never calls Apple. The ASC API key file is still prepared for the \`altool --upload-app\` step that follows.

## Manual step required before this can ship

The currently-orphaned Apple Development certs need to be revoked in the Apple Developer portal so the team has room to sign — this PR only stops the bleeding, it doesn't free the slots already burned. Path: portal → Certificates → revoke any \`Apple Development\` cert that isn't on a Mac you actively use. Don't touch \`Apple Distribution\` (that's the one CI imports).

## Test plan

- [ ] Revoke orphaned dev certs in the Apple Developer portal
- [ ] Re-run the Release workflow (workflow_dispatch with \`version=1.3.0\`) after merge — archive should succeed without minting any new certs
- [ ] Confirm the IPA exports cleanly with the AppStore profiles
- [ ] Confirm TestFlight upload still works (altool still has the API key)
- [ ] Verify local Xcode iOS development still works (Debug config is unchanged)

## Note

This is independent of the upcoming v1.3.0 release that ships the force-update gate. Either order is fine, but if you ship 1.3.0 first you'll hit this same cert wall, so this should land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)