### PR TITLE
fix(macos): restore CloudKit pull sync and stop CLI SIGABRT on exit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,11 +170,17 @@ jobs:
           SANITIZED="${RUNNER_TEMP}/toss-release.entitlements"
           cp toss/toss.entitlements "${SANITIZED}"
 
-          # Strip aps-environment: the source file declares "development" but
-          # the Developer ID profile authorizes "production"; signed entitlements
-          # must be a subset of the profile and we don't use APNs on macOS.
-          /usr/libexec/PlistBuddy -c "Delete :aps-environment" "${SANITIZED}" 2>/dev/null || true
-          /usr/libexec/PlistBuddy -c "Delete :com.apple.developer.aps-environment" "${SANITIZED}" 2>/dev/null || true
+          # CloudKit silent push delivery on macOS goes over APNs, so the
+          # signed entitlements MUST declare aps-environment for the released
+          # build to receive remote-change notifications and pull tosses from
+          # iCloud into the local store. The source file carries "development"
+          # for local Debug builds (APNs sandbox), but the Developer ID
+          # provisioning profile only authorizes "production" — substitute the
+          # value here so signing succeeds and runtime sync actually works.
+          # Stripping these (the previous behavior) silently broke cross-device
+          # sync: each Mac became a write-only island.
+          /usr/libexec/PlistBuddy -c "Set :aps-environment production" "${SANITIZED}"
+          /usr/libexec/PlistBuddy -c "Set :com.apple.developer.aps-environment production" "${SANITIZED}"
 
           # Substitute $(CFBundleIdentifier) which xcodebuild expands at build
           # time but bare codesign does not.

--- a/Packages/TossKit/Sources/TossKit/Persistence/PersistenceStack.swift
+++ b/Packages/TossKit/Sources/TossKit/Persistence/PersistenceStack.swift
@@ -29,8 +29,25 @@ public enum TossPersistenceStack {
     }
   }
 
+  /// Selects how the resulting `ModelContainer` participates in CloudKit.
+  /// The app and share extension want full sync; the CLI wants to opt out
+  /// because instantiating `NSPersistentCloudKitContainer` from a
+  /// sub-bundled `.app` helper triggers a PushKit assertion at dealloc.
+  public enum CloudKitMode {
+    /// Wires the store to the private CloudKit database. Used by the
+    /// app and share extension — they own sync.
+    case automatic
+    /// Disables CloudKit entirely for this process. The CLI uses this
+    /// so `NSPersistentCloudKitContainer` never spins up `PKPushRegistry`,
+    /// which would otherwise SIGABRT during dealloc inside the
+    /// `Tossinger.app/Contents/Helpers/toss.app` helper bundle.
+    case disabled
+  }
+
   /// Builds the shared `ModelContainer`. Call once per process and reuse.
-  public static func makeContainer() throws -> ModelContainer {
+  /// The default mode (`.automatic`) keeps the existing app + share
+  /// extension behavior; the CLI passes `.disabled`.
+  public static func makeContainer(cloudKit: CloudKitMode = .automatic) throws -> ModelContainer {
     guard
       let containerURL = FileManager.default.containerURL(
         forSecurityApplicationGroupIdentifier: appGroupIdentifier
@@ -40,9 +57,16 @@ public enum TossPersistenceStack {
     }
 
     let storeURL = containerURL.appendingPathComponent(storeFilename)
+    let cloudKitDatabase: ModelConfiguration.CloudKitDatabase
+    switch cloudKit {
+    case .automatic:
+      cloudKitDatabase = .private(cloudKitContainerIdentifier)
+    case .disabled:
+      cloudKitDatabase = .none
+    }
     let configuration = ModelConfiguration(
       url: storeURL,
-      cloudKitDatabase: .private(cloudKitContainerIdentifier)
+      cloudKitDatabase: cloudKitDatabase
     )
 
     return try ModelContainer(

--- a/tossinger/Support/TossEnvironment.swift
+++ b/tossinger/Support/TossEnvironment.swift
@@ -16,8 +16,17 @@ enum TossEnvironment {
   /// shared SwiftData store. Throws `TossPersistenceStack.StackError` if
   /// the app group container is missing (i.e., the binary is not signed
   /// with the App Groups entitlement).
+  ///
+  /// CloudKit is explicitly disabled for the CLI for two reasons:
+  ///   1. A one-shot CLI invocation has no time to await async push
+  ///      delivery anyway — the main app owns sync.
+  ///   2. Instantiating `NSPersistentCloudKitContainer` from a
+  ///      sub-bundled `.app` helper triggers a `PKPushRegistry` assertion
+  ///      ("Invalid parameter not satisfying: bundleIdentifier") during
+  ///      dealloc, SIGABRTing the CLI at process exit. Opting out via
+  ///      `.disabled` skips that code path entirely.
   static func repository() throws -> TossRepository {
-    let container = try TossPersistenceStack.makeContainer()
+    let container = try TossPersistenceStack.makeContainer(cloudKit: .disabled)
     return TossRepository(container: container)
   }
 }


### PR DESCRIPTION
## Summary

Two related production bugs surfacing as one user-visible problem: the CLI is unusable across machines.

### Bug 1: Cross-machine data divergence

The Mac mini and MacBook show completely different sets of tosses despite both being signed in to the same iCloud account, both running the same release, and both pointing at the same \`iCloud.lutra-labs.toss\` container.

\`release.yml:173-177\` strips both \`aps-environment\` and \`com.apple.developer.aps-environment\` from the macOS app's signed entitlements before codesigning, with a comment claiming *"we don't use APNs on macOS."* That's wrong on a load-bearing point: **\`NSPersistentCloudKitContainer\` (the engine SwiftData uses for \`cloudKitDatabase: .private(...)\` mode) needs \`aps-environment\` to receive CloudKit silent push notifications.** Without it the OS never wakes the app for "remote changes happened" pushes, so the local SwiftData store never *pulls* from CloudKit. Each Mac becomes a write-only island whose store reflects only what that machine itself wrote.

I verified the parent app's embedded provisioning profile (\`/Applications/Tossinger.app/Contents/embedded.provisionprofile\`) authorizes \`aps-environment: production\`, so the entitlement *can* be present — the workflow just deletes it. The fix substitutes the value (development → production) instead of stripping the keys.

### Bug 2: CLI SIGABRTs at process exit

\`toss ls\` consistently crashes after printing results with:

\`\`\`
NSInternalInconsistencyException 'Invalid parameter not satisfying: bundleIdentifier...'
  -[PKUserNotificationsRemoteNotificationServiceConnection initWithBundleIdentifier:]
  -[PKPushRegistry _registerForPushType:]
  -[NSCloudKitMirroringDelegate dealloc]
  -[NSPersistentStore dealloc]
  TossKit Container.deinit
  ListCommand.run
\`\`\`

Read bottom-up: the command finishes, prints results, exits → SwiftData tears down → \`NSPersistentCloudKitContainer\` deallocs → CloudKit cleanup tries to register for push types via \`PKPushRegistry\` → PushKit looks up the bundle identifier through some path that doesn't work for a sub-bundled \`.app\` helper invoked via \`/opt/homebrew/bin/toss → /Applications/Tossinger.app/Contents/Helpers/toss.app/Contents/MacOS/toss\` → \`bundleIdentifier\` resolves to nil → assertion fails → SIGABRT.

The CLI doesn't actually need CloudKit. It opens the same SQLite store as the main app via the app group, performs a single read or write, and exits. CloudKit sync is the main app's job.

## Changes

**\`.github/workflows/release.yml\`** (\`Prepare sanitized entitlements\` step) — replace the two \`Delete :*aps-environment*\` PlistBuddy lines with \`Set ... production\`. Updated the misleading comment to explain why APNs is actually load-bearing for CloudKit silent push.

**\`Packages/TossKit/Sources/TossKit/Persistence/PersistenceStack.swift\`** — added a public \`CloudKitMode\` enum with two cases:
- \`.automatic\` — wires the store to the private CloudKit database (current behavior)
- \`.disabled\` — uses \`ModelConfiguration.CloudKitDatabase.none\`, preventing \`NSPersistentCloudKitContainer\` from being instantiated at all

\`makeContainer\` now takes \`cloudKit: CloudKitMode = .automatic\`, so the app and share extension are bytewise-equivalent at runtime through the default.

**\`tossinger/Support/TossEnvironment.swift\`** — passes \`cloudKit: .disabled\`. Doc comment explains the rationale (CLI doesn't await async push delivery anyway, and instantiating the CloudKit container in a sub-bundled helper SIGABRTs).

Same store file, same data; only the transport layer for the CLI changes.

## Test plan

- [ ] Build the CLI helper in Xcode after the TossKit + TossEnvironment edits — should compile cleanly
- [ ] Run \`toss ls\` against the existing populated store — results print, process exits cleanly with no SIGABRT and no PushKit assertion in the logs
- [ ] Run \`toss add "https://example.com"\` and \`toss delete <id>\` — same expectation, no crashes
- [ ] Run \`toss ls\` 10× in a row on the macOS box where the crash was reproducible — expect zero crashes
- [ ] Build and run the main macOS app — behaves identically to before (default \`.automatic\` mode → same \`.private(...)\` configuration)
- [ ] Cut a release with this branch and inspect the workflow log for the \`Prepare sanitized entitlements\` step — the dumped plist (\`cat \"\${SANITIZED}\"\` already in the step) should now show \`aps-environment: production\` and \`com.apple.developer.aps-environment: production\`
- [ ] Confirm \`codesign --verify --strict --verbose=2\` (already in the workflow at line 205) still passes — entitlements remain a subset of what the Developer ID profile authorizes
- [ ] Install the new release on both Mac mini and MacBook, add a toss on one, wait ~30s, verify it appears on the other without manual refresh
- [ ] Run \`toss ls\` on both machines after sync settles — they should converge

## Notes

- The two open PRs (this one + #16 cert spam) touch different regions of \`release.yml\` (this one edits ~line 176, #16 edits ~lines 437/450) so they shouldn't conflict whichever order they merge in.
- The share extension stays on the default \`.automatic\` mode — iOS extensions don't have the CLI's PushKit instantiation problem since they run in the parent app's bundle context. Could be revisited if it ever proves problematic.
- Existing \`~/Library/Group Containers/group.lutra-labs.toss/default.store\` files (which carry CloudKit sync metadata from prior \`.private(...)\` use) open cleanly with \`.none\` — opening a CloudKit-mirrored store from a non-CloudKit context is a supported pattern and a no-op on the metadata side. The next time the app runs with full CloudKit it picks up CLI-written rows via NSPersistentHistoryTracker and pushes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)