### PR TITLE
fix(macos): drop iOS-shaped aps-environment from signed entitlements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,15 +171,25 @@ jobs:
           cp toss/toss.entitlements "${SANITIZED}"
 
           # CloudKit silent push delivery on macOS goes over APNs, so the
-          # signed entitlements MUST declare aps-environment for the released
-          # build to receive remote-change notifications and pull tosses from
-          # iCloud into the local store. The source file carries "development"
-          # for local Debug builds (APNs sandbox), but the Developer ID
-          # provisioning profile only authorizes "production" — substitute the
-          # value here so signing succeeds and runtime sync actually works.
-          # Stripping these (the previous behavior) silently broke cross-device
-          # sync: each Mac became a write-only island.
-          /usr/libexec/PlistBuddy -c "Set :aps-environment production" "${SANITIZED}"
+          # signed entitlements must declare the APNs entitlement for the
+          # released build to receive remote-change notifications and pull
+          # tosses from iCloud into the local store.
+          #
+          # On macOS the runtime key is `com.apple.developer.aps-environment`
+          # (all developer entitlements live under the com.apple.developer.*
+          # namespace). The bare `aps-environment` key is the iOS convention
+          # and is NOT authorized by the macOS Developer ID provisioning
+          # profile — if you leave it in, amfi kills the binary at exec with
+          # "Code Signature Invalid" because a restricted entitlement isn't
+          # profile-backed. codesign --verify doesn't catch this since it
+          # only checks structural validity; amfi is the one that enforces
+          # the profile subset at runtime.
+          #
+          # The source file declares both keys with value "development" for
+          # local Debug builds (iOS/macOS multiplatform target). Here we
+          # strip the iOS-shaped bare key and substitute the macOS key to
+          # "production" since the Developer ID profile authorizes that.
+          /usr/libexec/PlistBuddy -c "Delete :aps-environment" "${SANITIZED}" 2>/dev/null || true
           /usr/libexec/PlistBuddy -c "Set :com.apple.developer.aps-environment production" "${SANITIZED}"
 
           # Substitute $(CFBundleIdentifier) which xcodebuild expands at build


### PR DESCRIPTION
## Summary

v1.3.1 is dead on arrival: every launch SIGKILLs with \`Termination Reason: Namespace CODESIGNING, Code 1, Taskgated Invalid Signature\`. Diagnosed via side-by-side of the shipped binary's signed entitlements vs. its embedded provisioning profile:

| Signed in v1.3.1 binary | Authorized by profile |
|---|---|
| \`aps-environment: production\` | **NOT PRESENT** |
| \`com.apple.developer.aps-environment: production\` | ✅ present |

The bare \`aps-environment\` key is the iOS convention. macOS uses only the \`com.apple.developer.*\` namespace for developer entitlements, and the Developer ID provisioning profile authorizes \`com.apple.developer.aps-environment\` but not the bare iOS-shaped key. amfi enforces "every restricted entitlement must be profile-backed" at load time, so the bare key — which #17 started adding alongside the correct one — causes amfi to SIGKILL the binary on exec.

\`codesign --verify --strict\` in CI didn't catch this because it only validates structural integrity, not profile subset. That's amfi's job and it only runs at load time on the end-user's machine.

## Changes

**\`.github/workflows/release.yml\`** — in the \`Prepare sanitized entitlements\` step, **delete** the bare \`aps-environment\` key on macOS releases instead of substituting it. Keep the \`Set :com.apple.developer.aps-environment production\` line — that's the macOS runtime key for CloudKit silent push delivery, and it IS in the profile's authorized list.

## Test plan

- [ ] Merge this PR and let release-please open the v1.3.2 PR
- [ ] Merge v1.3.2 release PR
- [ ] Re-verify the \`Prepare sanitized entitlements\` log in the v1.3.2 release workflow — the dumped plist should show \`com.apple.developer.aps-environment: production\` and NO bare \`aps-environment\` key
- [ ] After release ships: \`brew upgrade --cask tossinger\` on both Mac mini and MacBook
- [ ] Launch the app — should no longer crash with SIGKILL
- [ ] Add a toss on one machine, wait ~30s, verify it appears on the other (cross-machine CloudKit push sync should work since \`com.apple.developer.aps-environment\` is present)
- [ ] Run \`toss ls\` — should exit cleanly (CLI opt-out from #17 still applies)

## Notes

- This PR reverses **only the iOS-shaped half** of the APNs entitlement work from #17. The CLI CloudKit opt-out and the iOS cert-spam fix from #16 are untouched.
- #17's \`toss/toss.entitlements\` source file still declares both keys with value \`development\` — that's fine for local Debug Xcode builds (Xcode automatic signing handles the iOS/macOS key split per-platform). The release workflow is the only place we need to strip the iOS shape for macOS distribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)