### PR TITLE
feat(sync): CloudKit sync status indicator + crisper card hover

### DIFF
--- a/Packages/TossKit/Sources/TossKit/Persistence/CloudSyncMonitor.swift
+++ b/Packages/TossKit/Sources/TossKit/Persistence/CloudSyncMonitor.swift
@@ -1,0 +1,55 @@
+//
+//  CloudSyncMonitor.swift
+//  TossKit
+//
+//  Observes NSPersistentCloudKitContainer.eventChangedNotification and exposes
+//  a coarse idle/syncing/failed state for SwiftUI. SwiftData's ModelContainer
+//  is built on NSPersistentCloudKitContainer, which posts this notification on
+//  the default NotificationCenter regardless of how the store was configured.
+//
+
+import CoreData
+import Foundation
+
+@MainActor
+public final class CloudSyncMonitor: ObservableObject {
+  public enum State: Equatable {
+    case idle
+    case syncing
+    case failed(message: String)
+  }
+
+  @Published public private(set) var state: State = .idle
+
+  private var task: Task<Void, Never>?
+
+  public init() {}
+
+  public func start() {
+    guard task == nil else { return }
+    task = Task { @MainActor [weak self] in
+      let name = NSPersistentCloudKitContainer.eventChangedNotification
+      for await notification in NotificationCenter.default.notifications(named: name) {
+        guard let self else { return }
+        guard
+          let event = notification.userInfo?[
+            NSPersistentCloudKitContainer.eventNotificationUserInfoKey
+          ] as? NSPersistentCloudKitContainer.Event,
+          event.type != .setup
+        else { continue }
+
+        if event.endDate == nil {
+          self.state = .syncing
+        } else if let error = event.error {
+          self.state = .failed(message: error.localizedDescription)
+        } else {
+          self.state = .idle
+        }
+      }
+    }
+  }
+
+  deinit {
+    task?.cancel()
+  }
+}

--- a/toss/Views/Tosses/TossCard.swift
+++ b/toss/Views/Tosses/TossCard.swift
@@ -27,13 +27,24 @@ struct TossCard: View {
     #if os(macOS)
       .onHover { hovering in
         isHovered = hovering
+        if hovering {
+          NSCursor.pointingHand.push()
+        } else {
+          NSCursor.pop()
+        }
       }
       .shadow(
-        color: .black.opacity(isHovered ? 0.08 : 0.03),
-        radius: isHovered ? 4 : 2,
-        y: 1
+        color: .black.opacity(isHovered ? 0.12 : 0.03),
+        radius: isHovered ? 6 : 2,
+        y: isHovered ? 2 : 1
       )
-      .scaleEffect(isHovered ? 1.005 : 1.0)
+      .overlay {
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+          .strokeBorder(
+            Color.accentColor.opacity(isHovered ? 0.35 : 0),
+            lineWidth: 1.5
+          )
+      }
     #endif
   }
 

--- a/toss/Views/Tosses/TossesView.swift
+++ b/toss/Views/Tosses/TossesView.swift
@@ -20,6 +20,7 @@ struct TossesView: View {
   @Environment(\.modelContext) private var modelContext
 
   @StateObject private var viewModel = TossesViewModel()
+  @EnvironmentObject private var cloudSyncMonitor: CloudSyncMonitor
   @State private var showingAddToss = false
   @State private var editingToss: Toss?
   @State private var selectedToss: Toss?
@@ -85,6 +86,16 @@ struct TossesView: View {
       }
       .toolbar {
         #if os(macOS)
+          if #available(macOS 26.0, *) {
+            ToolbarItem(placement: .principal) {
+              CloudSyncIndicator(state: cloudSyncMonitor.state)
+            }
+            .sharedBackgroundVisibility(.hidden)
+          } else {
+            ToolbarItem(placement: .principal) {
+              CloudSyncIndicator(state: cloudSyncMonitor.state)
+            }
+          }
           ToolbarItem(placement: .primaryAction) {
             Button {
               showingAddToss = true
@@ -93,6 +104,16 @@ struct TossesView: View {
             }
           }
         #else
+          if #available(iOS 26.0, *) {
+            ToolbarItem(placement: .topBarLeading) {
+              CloudSyncIndicator(state: cloudSyncMonitor.state)
+            }
+            .sharedBackgroundVisibility(.hidden)
+          } else {
+            ToolbarItem(placement: .topBarLeading) {
+              CloudSyncIndicator(state: cloudSyncMonitor.state)
+            }
+          }
           ToolbarItem(placement: .topBarTrailing) {
             Button {
               showingAddToss = true
@@ -181,5 +202,29 @@ struct TossesView: View {
     #else
       16
     #endif
+  }
+}
+
+private struct CloudSyncIndicator: View {
+  let state: CloudSyncMonitor.State
+
+  var body: some View {
+    ZStack {
+      switch state {
+      case .idle:
+        Color.clear
+      case .syncing:
+        ProgressView()
+          .controlSize(.small)
+          .accessibilityLabel("Syncing with iCloud")
+      case .failed(let message):
+        Image(systemName: "exclamationmark.icloud")
+          .foregroundStyle(.orange)
+          .help(message)
+          .accessibilityLabel("iCloud sync failed")
+          .accessibilityHint(message)
+      }
+    }
+    .frame(width: 18, height: 18)
   }
 }

--- a/toss/tossApp.swift
+++ b/toss/tossApp.swift
@@ -14,6 +14,7 @@ struct tossApp: App {
   var container: ModelContainer
   @StateObject private var appSettings = AppSettings()
   @StateObject private var updateGate = UpdateGateService()
+  @StateObject private var cloudSyncMonitor = CloudSyncMonitor()
   #if os(macOS)
     @StateObject private var macGlobalShortcutController = MacGlobalShortcutController()
   #endif
@@ -40,8 +41,10 @@ struct tossApp: App {
       }
         .environmentObject(appSettings)
         .environmentObject(updateGate)
+        .environmentObject(cloudSyncMonitor)
         .tint(Color.accentColor)  // Apply accent color globally
         .onAppear {
+          cloudSyncMonitor.start()
           uuidMigration.startIfNeeded(modelContainer: container)
           backfillMigration.startIfNeeded(modelContainer: container)
           #if os(macOS)


### PR DESCRIPTION
## Summary

- Adds a small CloudKit sync status indicator to the `TossesView` toolbar (principal on macOS, top-leading on iOS). Shows a spinner while `.import`/`.export` events are in flight and an `exclamationmark.icloud` icon with a tooltip on error, auto-clearing on the next successful event. `.setup` events are filtered so cold launches don't spin.
- Implemented via a new `@MainActor` `CloudSyncMonitor` in `TossKit` that subscribes to `NSPersistentCloudKitContainer.eventChangedNotification` — the Apple-documented path for observing sync in a SwiftData + CloudKit stack (SwiftData's `ModelContainer` is still backed by `NSPersistentCloudKitContainer` and posts this notification globally).
- The indicator uses a fixed 18pt frame so the toolbar never reflows between idle and syncing, and opts out of the macOS/iOS 26 shared Liquid Glass background via `.sharedBackgroundVisibility(.hidden)` (gated with `#available` for older OSes).
- Replaces the 0.5% `scaleEffect` hover feedback on `TossCard` with a stronger shadow, an inner accent-colored border overlay, and a pointing-hand cursor. The fractional scale was forcing subpixel resampling and making the card look faintly blurry on hover.

## Why

CloudKit sync is currently invisible to the user — when it silently broke recently (iOS↔macOS CloudKit environment mismatch) there was no signal at all. Apple's own guidance is that event notifications describe *activity*, not definitive "fully synced" truth, so the UX is deliberately minimal: transient spinner only, auto-clearing error icon, nothing persistent, no "last synced at X" text.

## Test plan

- [ ] Launch on macOS; toolbar looks unchanged at idle (no bezel, no empty slot).
- [ ] Add a toss on the Mac; spinner appears briefly in the toolbar between "Tosses" and `+`, then disappears.
- [ ] Add a toss on a second device on the same iCloud account; first Mac shows a spinner when the `.import` event arrives and the toss appears in the list.
- [ ] Sign out of iCloud, add a toss; orange `exclamationmark.icloud` shows with tooltip. Sign back in and add another toss; icon auto-clears.
- [ ] Cold-launch several times; no spinner during `.setup` (filtered).
- [ ] Hover a toss card on macOS; border + shadow + cursor change, no blur.
- [ ] Build on iOS — `.topBarLeading` placement looks correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)