### PR TITLE
fix(share): close CloudKit sync gap from iOS share extension

### DIFF
--- a/toss/Info.plist
+++ b/toss/Info.plist
@@ -2,6 +2,19 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>lutra-labs.toss</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>tossinger</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSAccessibilityUsageDescription</key>
 	<string>Tossinger needs Accessibility access to capture selected text from other apps when you use the global shortcut (experimental).</string>
 	<key>UIBackgroundModes</key>

--- a/toss/Services/AppSettings.swift
+++ b/toss/Services/AppSettings.swift
@@ -11,6 +11,12 @@ import TossKit
 
 @MainActor
 class AppSettings: ObservableObject {
+  // Shared with the iOS share extension via the app group so both processes
+  // see the same value for `autoOpenAfterSharing`. Existing single-process
+  // preferences below continue to live in UserDefaults.standard so they
+  // aren't wiped on upgrade.
+  static let sharedDefaults = UserDefaults(suiteName: TossPersistenceStack.appGroupIdentifier)!
+
   @AppStorage("biometric_enabled") var isBiometricEnabled: Bool = false
 
   @AppStorage("layout_mode") private var layoutModeRaw: String = TossLayoutMode.grid.rawValue
@@ -19,4 +25,7 @@ class AppSettings: ObservableObject {
     get { TossLayoutMode(rawValue: layoutModeRaw) ?? .grid }
     set { layoutModeRaw = newValue.rawValue }
   }
+
+  @AppStorage("auto_open_after_share", store: AppSettings.sharedDefaults)
+  var autoOpenAfterSharing: Bool = false
 }

--- a/toss/Views/Settings/SettingsView.swift
+++ b/toss/Views/Settings/SettingsView.swift
@@ -271,6 +271,7 @@ struct SettingsView: View {
       NavigationStack {
         Form {
           securitySection
+          sharingSection
           aboutSection
 
           Section {
@@ -422,6 +423,35 @@ struct SettingsView: View {
       Text("About")
     }
   }
+
+  #if os(iOS)
+    private var sharingSection: some View {
+      Section {
+        Toggle(isOn: $appSettings.autoOpenAfterSharing) {
+          HStack(spacing: 12) {
+            Image(systemName: "square.and.arrow.up")
+              .foregroundStyle(.blue)
+              .font(.title3)
+              .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: 2) {
+              Text("Auto-open app after sharing")
+                .font(.body)
+              Text("Ensures tosses sync to iCloud immediately")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+          }
+        }
+      } header: {
+        Text("Sharing")
+      } footer: {
+        Text(
+          "When off, tosses shared from other apps are saved locally and only reach iCloud the next time you open Tossinger. Turn on to briefly open Tossinger after each share so changes sync immediately."
+        )
+      }
+    }
+  #endif
 }
 
 #Preview {

--- a/toss/tossApp.swift
+++ b/toss/tossApp.swift
@@ -74,6 +74,13 @@ struct tossApp: App {
             break
           }
         }
+        #if os(iOS)
+          .onOpenURL { _ in
+            // Intentional no-op. The share extension opens `tossinger://share-complete`
+            // purely to foreground Tossinger so NSPersistentCloudKitContainer can
+            // complete its pending CloudKit export. The URL itself carries no data.
+          }
+        #endif
     }
     .modelContainer(container)
     #if os(macOS)

--- a/tossShare/ShareViewController.swift
+++ b/tossShare/ShareViewController.swift
@@ -30,6 +30,26 @@ final class ShareViewController: UIViewController {
   private let successLabel = UILabel()
   private var didCompleteRequest = false
 
+  /// User-opt-in flag read from the app-group UserDefaults, written by the
+  /// main app's Settings screen. When true, the extension foregrounds the
+  /// main Tossinger app after saving so NSPersistentCloudKitContainer can
+  /// complete its pending CloudKit export (extensions cannot finish the
+  /// export themselves from a short-lived process).
+  private let autoOpenAfterSharing: Bool = {
+    UserDefaults(suiteName: TossPersistenceStack.appGroupIdentifier)?
+      .bool(forKey: "auto_open_after_share") ?? false
+  }()
+
+  private var successMessage: String {
+    autoOpenAfterSharing
+      ? "Tossed. Opening app…"
+      : "Tossed. Open app to sync."
+  }
+
+  private var successCloseDelay: TimeInterval {
+    autoOpenAfterSharing ? 0.35 : 0.8
+  }
+
   override func viewDidLoad() {
     super.viewDidLoad()
     setupUI()
@@ -44,7 +64,7 @@ final class ShareViewController: UIViewController {
     view.backgroundColor = .systemBackground
 
     // Configure success label
-    successLabel.text = "Tossed and syncing..."
+    successLabel.text = successMessage
     successLabel.font = .systemFont(ofSize: 17, weight: .medium)
     successLabel.textAlignment = .center
     successLabel.textColor = .label
@@ -167,7 +187,7 @@ final class ShareViewController: UIViewController {
 
     do {
       try context.save()
-      showMessage("Tossed and syncing...")
+      showMessage(successMessage)
     } catch {
       showMessageAndClose("Failed to save toss.")
       return
@@ -189,7 +209,7 @@ final class ShareViewController: UIViewController {
       // Keep the initial save; metadata enrichment is best-effort.
     }
 
-    closeExtension(after: 0.35)
+    finishAfterSuccess()
   }
 
   private func applyMetadata(_ result: MetadataResult, to toss: Toss) {
@@ -262,7 +282,21 @@ final class ShareViewController: UIViewController {
   }
 
   private func showSuccessAndClose() {
-    showMessageAndClose("Tossed and syncing...")
+    showMessage(successMessage)
+    finishAfterSuccess()
+  }
+
+  /// Close path for a successful save. If the user opted into auto-open, the
+  /// extension foregrounds the containing app via its custom URL scheme so
+  /// NSPersistentCloudKitContainer can complete its CloudKit export. The
+  /// extension always tears itself down afterwards — `completeRequest` is
+  /// called unconditionally via `closeExtension(after:)` so the extension
+  /// exits even if `open` was denied by the system.
+  private func finishAfterSuccess() {
+    if autoOpenAfterSharing, let url = URL(string: "tossinger://share-complete") {
+      extensionContext?.open(url, completionHandler: nil)
+    }
+    closeExtension(after: successCloseDelay)
   }
 
   private func closeExtension(after delay: TimeInterval = 0) {


### PR DESCRIPTION
## Summary

Fixes a silent CloudKit sync gap in the iOS share extension. When you share from Safari to Tossinger, the record has been saving locally on the phone but never reaching iCloud until the next time you manually launch the main app — so the Mac sat there with nothing new. The old success label ("Tossed and syncing…") was actively dishonest about this.

Two changes in one PR:

1. **Always-on copy fix.** Success label now reads **"Tossed. Open app to sync."** and is displayed ~0.8s so users can actually read it. Informational only — no behavior change beyond the text.
2. **Opt-in auto-open (new iOS Settings toggle).** New **Sharing → Auto-open app after sharing** toggle (default OFF). When enabled, the share extension calls `extensionContext.open("tossinger://share-complete")` after the local save, which briefly foregrounds the main app so `NSPersistentCloudKitContainer` can run its setup → export cycle. Tradeoff (sharing interrupts whatever the user was doing) is explained in the section footer. Label changes to **"Tossed. Opening app…"** when opt-in is on.

## Why this approach

`NSPersistentCloudKitContainer` cannot complete a CloudKit export from inside a short-lived share-extension process — confirmed on Apple Developer Forums, reproduced across iOS 17/18/26. The supported workaround is to foreground the containing app briefly, which is what `extensionContext.open(_:)` does. Direct `CKModifyRecordsOperation` from the extension would technically work but requires reverse-engineering the private `CD_Toss` CKRecord schema and is fragile across iOS releases — skipped.

## Architecture notes

- **App-group UserDefaults for the one new flag only.** Extensions can't read `UserDefaults.standard` of the main app (per-process). New `AppSettings.sharedDefaults` static points at `group.lutra-labs.toss` (reusing `TossPersistenceStack.appGroupIdentifier`, already public). Existing `biometric_enabled` and `layout_mode` stay in `UserDefaults.standard` so installed users don't lose preferences on upgrade.
- **Extension reads `UserDefaults` directly, not `AppSettings`.** `AppSettings` is a `@MainActor ObservableObject` with SwiftUI dependencies that would be awkward to instantiate in a UIKit extension. One-line `UserDefaults(suiteName:)?.bool(forKey:)` read at instance-init time is enough.
- **`.onOpenURL` is a no-op stub.** The sole purpose of the URL scheme is to force iOS to foreground Tossinger; we don't do anything with the URL. Launching is what triggers CloudKit export. Comment in the handler explains why it's intentionally empty.
- **Default OFF for auto-open.** Making it on would silently start yanking users out of Safari on every share — hostile surprise. Opt-in only.
- **macOS untouched.** No share extension on macOS, no equivalent sync gap (the menu-bar app process is typically always running so exports complete normally).

## Files changed

- `toss/Services/AppSettings.swift` — new `sharedDefaults` static + `autoOpenAfterSharing` property
- `toss/Info.plist` — `CFBundleURLTypes` registering `tossinger://`
- `toss/tossApp.swift` — iOS-only `.onOpenURL { _ in }` no-op on root scene
- `toss/Views/Settings/SettingsView.swift` — new iOS-only `sharingSection` between Security and About
- `tossShare/ShareViewController.swift` — reads preference, computes honest success copy, new `finishAfterSuccess()` helper routes through `extensionContext.open` when opt-in is on

## Test plan

Manual device test (simulators don't exercise CloudKit sync between devices):

- [ ] Force-quit Tossinger on iPhone, share from Safari — label reads "Tossed. Open app to sync." for ~0.8s.
- [ ] Mac doesn't receive the toss yet (baseline sync gap still present, expected — Change A is informational only).
- [ ] Open Tossinger on iPhone once — Mac receives the toss within a few seconds.
- [ ] Enable **Settings → Sharing → Auto-open app after sharing**.
- [ ] Force-quit Tossinger, share again — label reads "Tossed. Opening app…", iPhone briefly foregrounds Tossinger, Mac receives the toss within ~5s without manual iOS launch.
- [ ] Quit and relaunch Tossinger — toggle state persists (confirms app-group UserDefaults is sticking).
- [ ] Toggle off — back to informational copy.
- [ ] URL scheme sanity: `xcrun simctl openurl booted tossinger://share-complete` opens Tossinger (no crash, no Safari fallback).
- [ ] macOS Settings regression: "Sharing" section does NOT appear on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)